### PR TITLE
Recommendation

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -854,6 +854,15 @@ Generic error type. The error message, in the `.msg` field, may provide more spe
 ErrorException
 
 """
+    WrappedException(msg)
+
+Generic type for `Exception`s wrapping another `Exception`, such as `LoadError` and
+`InitError`. Those exceptions contain information about the the root cause of an
+exception. Subtypes define a field `error` containing the causing `Exception`.
+"""
+WrappedException
+
+"""
     UndefRefError()
 
 The item or field is not defined for the given object.


### PR DESCRIPTION
Hi Aida!

I thought it might be helpful to show you what dropping the docstring for `WrappedException` into `basedocs.jl` might look like. Note that under the docstring, `WrappedException` is written (without any information about types) so that the docstring becomes attached to the relevant functionality even though `WrappedException` is declared in another file (`boot.jl`). Feel free to ignore this PR; it's just meant to provide an example.

Let me know if you need anything!